### PR TITLE
Update examples/bolts/splitsentence.php

### DIFF
--- a/examples/bolts/splitsentence.php
+++ b/examples/bolts/splitsentence.php
@@ -5,7 +5,7 @@ require_once('../../lib/storm.php');
 
 class SplitSentenceBolt extends BasicBolt
 {
-	public function process($tuple)
+	public function process(Tuple $tuple)
 	{
 		$words = explode(" ", $tuple->values[0]);
 		foreach($words as $word)


### PR DESCRIPTION
To avoid this error?

PHP Fatal error:  Declaration of SplitSentenceBolt::process() must be compatible with that of ShellBolt::process()
